### PR TITLE
Fix diffs shown on Conversation tab and default size

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,7 +1,18 @@
 chrome.tabs.onUpdated.addListener(function(tabId, updateInfo, tab) {
   if (updateInfo.status == "complete") {
     chrome.storage.sync.get("tabSize", function(items) {
-      chrome.tabs.insertCSS(tabId, {code: ".tab-size[data-tab-size='2'], .tab-size[data-tab-size='4'], .tab-size[data-tab-size='8'], .inline-review-comment, .gist table.lines { tab-size: " + items.tabSize + " !important; }"});
+      chrome.tabs.insertCSS(tabId, {
+        code: `
+          .tab-size[data-tab-size='2'],
+          .tab-size[data-tab-size='4'],
+          .tab-size[data-tab-size='8'],
+          .inline-review-comment,
+          .gist table.lines,
+          .blob-code {
+            tab-size: ${items.tabSize || 4} !important;
+          }
+        `
+      });
     })
   }
 });


### PR DESCRIPTION
Since GitHub launched PR reviews feature, this extension (well, I was using the original, not your fork) hasn't changed the tab size on the Conversation tab of a PR. This fixes that. Also fixes a problem I ran into out of the box installing the extension: `tabSize` was apparently `undefined` since I hadn't run the settings screen yet.